### PR TITLE
Quick fix Error Coercion that currently crash Travis Flash Test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,8 @@ install:
 script:
   - haxe build-js.hxml           && node bin/MainUnitTest.js
   - haxe build-flash.hxml -D fdb && haxe flash/run.hxml bin/MainUnitTest.swf
-  
+
 notifications:
   email:
     recipients:
-      - francis_bourre@me.com
-      - peterphonix@gmail.com
+      - laurent@geturl.net

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,4 +55,5 @@ script:
 notifications:
   email:
     recipients:
-      - laurent@geturl.net
+      - francis_bourre@me.com
+      - peterphonix@gmail.com

--- a/src/hex/unittest/event/MethodRunnerEvent.hx
+++ b/src/hex/unittest/event/MethodRunnerEvent.hx
@@ -2,7 +2,6 @@ package hex.unittest.event;
 
 import hex.unittest.description.TestMethodDescriptor;
 import hex.unittest.runner.MethodRunner;
-import hex.error.Exception;
 import hex.event.BasicEvent;
 
 /**
@@ -19,9 +18,9 @@ class MethodRunnerEvent extends BasicEvent
 
     private var _descriptor             : TestMethodDescriptor;
     private var _timeElapsed            : Float;
-    private var _error                  : Exception;
+    private var _error                  : Dynamic;
 
-    public function new ( type : String, target : MethodRunner, descriptor : TestMethodDescriptor, timeElapsed : Float, ?error : Exception )
+    public function new ( type : String, target : MethodRunner, descriptor : TestMethodDescriptor, timeElapsed : Float, ?error : Dynamic )
     {
         super( type, target );
 
@@ -40,7 +39,7 @@ class MethodRunnerEvent extends BasicEvent
         return this._descriptor;
     }
 
-    public function getError() : Exception
+    public function getError() : Dynamic
     {
         return this._error;
     }
@@ -49,7 +48,7 @@ class MethodRunnerEvent extends BasicEvent
     {
         return this._timeElapsed;
     }
-	
+
 	override public function clone() : BasicEvent
     {
         return new MethodRunnerEvent( this.type, this.target, this._descriptor, this._timeElapsed, this._error );

--- a/src/hex/unittest/event/TestRunnerEvent.hx
+++ b/src/hex/unittest/event/TestRunnerEvent.hx
@@ -1,7 +1,6 @@
 package hex.unittest.event;
 
 import hex.event.BasicEvent;
-import hex.error.Exception;
 import hex.unittest.runner.TestRunner;
 import hex.unittest.description.TestClassDescriptor;
 
@@ -19,10 +18,10 @@ class TestRunnerEvent  extends BasicEvent
     public static inline var TEST_CLASS_END_RUN     : String = "onTestClassEndRun";
 
     private var _descriptor                         : TestClassDescriptor;
-    private var _error                              : Exception;
+    private var _error                              : Dynamic;
     private var _timeElapsed                        : Float;
 
-    public function new ( type : String, target : TestRunner, descriptor : TestClassDescriptor, ?timeElapsed : Float, ?error : Exception )
+    public function new ( type : String, target : TestRunner, descriptor : TestClassDescriptor, ?timeElapsed : Float, ?error : Dynamic )
     {
         super( type, target );
 
@@ -41,7 +40,7 @@ class TestRunnerEvent  extends BasicEvent
         return this._descriptor;
     }
 
-    public function getError() : Exception
+    public function getError() : Dynamic
     {
         return this._error;
     }
@@ -50,7 +49,7 @@ class TestRunnerEvent  extends BasicEvent
     {
         return this._timeElapsed;
     }
-	
+
 	override public function clone() : BasicEvent
 	{
 		return new TestRunnerEvent( this.type, this.target, this._descriptor, this._timeElapsed, this._error );


### PR DESCRIPTION
use Dynamic instead of hex.error.Exception 
To fix : Error #1034: Type Coercion failed: cannot convert TypeError to hex.error.Exception.

```
TraceNotifier.hx:27:        Suite class 'event'
TraceNotifier.hx:27:            Test class 'hex.event.CallbackAdapterTest'
TypeError: Error #1034: Type Coercion failed: cannot convert TypeError@31d9bb332ce1 to hex.error.Exception.
    at hex.unittest.runner::MethodRunner/run()[/Users/ali_o_kan/Documents/github/hexMVC/dependencies/hexunit/src/hex/unittest/runner/MethodRunner.hx:50]
    at hex.unittest.runner::TestRunner/_runTestClass()[/Users/ali_o_kan/Documents/github/hexMVC/dependencies/hexunit/src/hex/unittest/runner/TestRunner.hx:105]
    at MethodInfo-2105()[/Users/ali_o_kan/Documents/github/hexMVC/dependencies/hexunit/src/hex/unittest/runner/TestRunner.hx:190]
    at MethodInfo-137()[/usr/local/lib/haxe/std/haxe/Timer.hx:125]
    at MethodInfo-133()[/usr/local/lib/haxe/std/haxe/Timer.hx:62]
    at Function/http://adobe.com/AS3/2006/builtin::apply()
    at SetIntervalTimer/onTimer()
    at flash.utils::Timer/_timerDispatch()
    at flash.utils::Timer/tick()
```
